### PR TITLE
Fix pykerberos 1.2.1 with krb5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,57 +1,55 @@
-{% set name = "pykerberos" %}
-{% set version = "1.2.1" %}
-
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: pykerberos
+  version: 1.2.1
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  fn: pykerberos-1.2.1.tar.gz
+  url: https://pypi.org/packages/source/p/pykerberos/pykerberos-1.2.1.tar.gz
   sha256: 4f2dca8df5f84a3be039c026893850d731a8bb38395292e1610ffb0a08ba876c
   patches:
-    # fix issue with memcpy on macOS
-    # LICENSE: this patch is reproduced from the AnacondaRecipes/aggregate
-    #          recipe for this package, with permission from the author, see
-    #          https://github.com/conda-forge/staged-recipes/pull/10646#issuecomment-576312814
-    - 0001-Implement-mempcpy-via-memcpy.patch  # [osx]
+    - 0001-Implement-mempcpy-via-memcpy.patch
 
 build:
-  number: 5
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
-  skip: true  # [win]
+  number: 3
+  detect_binary_files_with_prefix: False
+  script: python setup.py install --single-version-externally-managed --root=/
+  # Use winkerberos on Windows
+  # https://github.com/02strich/pykerberos/issues/18
+  skip: True  # [win]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
+    - patch  # [not win]
   host:
-    - krb5
+    - python
     - pip
-    - python
     - setuptools
-  run:
+    - wheel
     - krb5
+  run:
     - python
+    - krb5
 
 test:
   imports:
     - kerberos
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: "https://github.com/02strich/pykerberos"
-  dev_url: "https://github.com/02strich/pykerberos"
-  doc_url: "https://pypi.python.org/pypi/kerberos"
-  license: "Apache-2.0"
-  license_family: "APACHE"
-  license_file: "LICENSE"
-  summary: "High-level interface to Kerberos"
+  home: https://github.com/02strich/pykerberos
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: high-level interface to Kerberos
   description: |
-    pykerberos is a high-level wrapper for Kerberos (GSSAPI) operations. The
-    goal is to avoid having to build a module that wraps the entire
-    Kerberos.framework and instead offer a limited set of functions that do
-    what is needed for client/server Kerberos authentication.
-
-extra:
-  recipe-maintainers:
-    - duncanmmacleod
+    pykerberos is a high-level wrapper for Kerberos (GSSAPI) operations. The goal is to
+    avoid having to build a module that wraps the entire Kerberos.framework
+    and instead offer a limited set of functions that do what is needed for
+    client/server Kerberos authentication.
+  dev_url: https://github.com/02strich/pykerberos
+  doc_url: https://pypi.python.org/pypi/kerberos
+  doc_source_url: https://github.com/apple/ccs-pykerberos/blob/master/README.rst


### PR DESCRIPTION
I create a build of `pykerberos ` that supports krb5>=1.19.1


Category:  other | subcategory:   | pkg_type:  python
Popularity:  121908 downloads -  pykerberos  1.2.1  High-level interface to Kerberos
  license: Apache
Release date:  Feb 27, 2020
Bug Tracker: new open issues https://github.com/02strich/pykerberos/issues
Github releases:  https://github.com/02strich/pykerberos/releases
License file:  https://github.com/02strich/pykerberos/blob/master/LICENSE
Upstream Changelog: https://github.com/02strich/pykerberos/blob/master/CHANGELOG.txt
Upstream setup.py:  https://github.com/02strich/pykerberos/blob/v1.2.1/setup.py

The package pykerberos is mentioned inside the packages:
airflow | requests-kerberos |

Actions:
1. Bump build number to `3`
2. Add `patch ` to the requirements/build section
3. Add missing packages to the host section: `pip`, `wheel`
4. Add `pip check` to the test/commands section
5. Update license and add license_family
6. Add dev_url

Result:
- all-succeeded
